### PR TITLE
`jsonjunit` wouldn't run when installed globally

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,13 +2,14 @@
 var program = require('commander'),
     fs = require('fs'),
     path = require('path'),
+    pkg = require('./package.json'),
     jsonJunit = require('./lib/jsonjunit'),
     fileName,
     jsonFile,
     junitFile;
 
 program
-    .version(JSON.parse(fs.readFileSync('./package.json', 'utf8')).version)
+    .version(pkg.version)
     .option('-ju, --json <json>', 'JSON report target path')
     .option('-jx, --junit <junit>', 'JUnitXML report destination path')
     //.option('-jt, --jsontype', 'Type of JSON report to convert')


### PR DESCRIPTION
The JS file is looking for the package.json which isn't available when installing with `npm i jsonjunit -g` and running from the CLI.

By `require`ing the package.json rather than reading the file in with `readFileSync`, it gets rid of the errors and allows you to run directly from the cli.

This makes adding the command to a jenkins job considerably easier!